### PR TITLE
Add two dataset papers and fix a broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ It is not exhaustive and will likely never be, but feel free to open a PR if you
 
 ### Datasets
 
+* Eilertsen et al - [Classifying the classifier: dissecting the weight space of neural networks](https://doi.org/10.48550/arXiv.2002.05688) (2020)
+* Unterthiner et al - [Predicting Neural Network Accuracy from Weights](https://doi.org/10.48550/arXiv.2002.11448) (2021)
 * Schürholt et al - [Model Zoos: A Dataset of Diverse Populations of Neural Network Models](https://proceedings.neurips.cc/paper_files/paper/2022/hash/f94d5edb5c01715d879693ddbfdc1b98-Abstract-Datasets_and_Benchmarks.html) (2022)
 
 ### Other

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ It is not exhaustive and will likely never be, but feel free to open a PR if you
 
 ### Datasets
 
-* Schürholt et al - [Model Zoos: A Dataset of Diverse Populations of Neural Network Models](https://proceedings.neurips.cc/paper/2022/hash/f3b7e5d3eb074cde5b76e26bc0fb5776-Abstract-Conference.html) (2022)
+* Schürholt et al - [Model Zoos: A Dataset of Diverse Populations of Neural Network Models](https://proceedings.neurips.cc/paper_files/paper/2022/hash/f94d5edb5c01715d879693ddbfdc1b98-Abstract-Datasets_and_Benchmarks.html) (2022)
 
 ### Other
 


### PR DESCRIPTION
Unterthiner et al. (2021) was already in there, but also added it to the datasets section because of the CNNZoo dataset it presents. Also added Eilertsen et al. (2020).

Fixed a broken link in the Schürholt et al. (2022) reference